### PR TITLE
Configure pymdownx emoji to use Material icons

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -21,6 +21,8 @@ markdown_extensions:
   - pymdownx.details
   - pymdownx.superfences
   - pymdownx.highlight
-  - pymdownx.emoji
+  - pymdownx.emoji:
+      emoji_index: !!python/name:materialx.emoji.twemoji
+      emoji_generator: !!python/name:materialx.emoji.to_svg
   - pymdownx.tasklist:
       custom_checkbox: true


### PR DESCRIPTION
## Summary
- configura la extensión `pymdownx.emoji` para usar el índice y generador de Material

## Testing
- mkdocs build

------
https://chatgpt.com/codex/tasks/task_e_68cc0433fa3c832e8ed7ed0fae02daf1